### PR TITLE
feat: add additional attributes

### DIFF
--- a/src/oidc_provider_mock/__main__.py
+++ b/src/oidc_provider_mock/__main__.py
@@ -68,6 +68,8 @@ def run(
     token_max_age: int,
 ):
     """Start an OpenID Connect Provider for testing"""
+    import os
+    print(os.getenv("OAUTHLIB_INSECURE_TRANSPORT"))
 
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(

--- a/src/oidc_provider_mock/__main__.py
+++ b/src/oidc_provider_mock/__main__.py
@@ -68,8 +68,6 @@ def run(
     token_max_age: int,
 ):
     """Start an OpenID Connect Provider for testing"""
-    import os
-    print(os.getenv("OAUTHLIB_INSECURE_TRANSPORT"))
 
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(

--- a/src/oidc_provider_mock/_app.py
+++ b/src/oidc_provider_mock/_app.py
@@ -139,6 +139,7 @@ def _user_claims_for_scope(user: User, scope: str) -> dict[str, object]:
             if name not in _STANDARD_CLAIMS or name in allowed_standard_claims_for_scope
         },
         "sub": user.sub,
+        **user.additional_attributes,
     }
 
 
@@ -569,7 +570,8 @@ SetUserBody = pydantic.RootModel[dict[str, object]]
 @blueprint.put("/users/<sub>")
 def set_user(sub: str):
     body = _validate_body(flask.request, SetUserBody)
-    storage.store_user(User(sub=sub, claims=body.root))
+    additional_attributes = body.root.pop("additional_attributes", {})
+    storage.store_user(User(sub=sub, claims=body.root, additional_attributes=additional_attributes))
     return "", HTTPStatus.NO_CONTENT
 
 

--- a/src/oidc_provider_mock/_storage.py
+++ b/src/oidc_provider_mock/_storage.py
@@ -92,6 +92,7 @@ class Client(authlib.oauth2.rfc6749.ClientMixin):
 class User:
     sub: str
     claims: dict[str, object] = field(default_factory=dict)
+    additional_attributes: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(kw_only=True, frozen=True)


### PR DESCRIPTION
hi @geigerzaehler!
I would like to have any additional data in token to perform my applications e2e testing,
please consider to accept it.

for example:

```json
{
    "email": "alice@example.com",
    "nickname": "Alice",
    "additional_attributes": {
        "groups": [
            "some-group",
            "another-group"
        ],
        "name": "Alice"
    }
}
```