### PR TITLE
feat: add cors headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+- Add CORS headers ([@tjarbo][])
+
 ## v0.4.0 - 2026-03-27
 
 - Update authorization UI ([@Kenneth-Sills][])

--- a/src/oidc_provider_mock/_app.py
+++ b/src/oidc_provider_mock/_app.py
@@ -187,6 +187,17 @@ authorization = cast(
 blueprint = flask.Blueprint("oidc-provider-mock", __name__)
 
 
+@blueprint.after_request
+def add_cors_headers(response: flask.Response) -> flask.Response:
+    if flask.request.endpoint == f"{blueprint.name}.{authorize.__name__}":
+        return response
+
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Headers"] = "*, Authorization"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, OPTIONS"
+    return response
+
+
 @dataclass(kw_only=True, frozen=True)
 class Config:
     require_client_registration: bool = False

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -3,11 +3,44 @@ from collections.abc import Callable
 from http import HTTPStatus
 
 import flask.testing
+import pytest
 
 import oidc_provider_mock
 import oidc_provider_mock._app
 
 from .conftest import use_provider_config
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/.well-known/openid-configuration",
+        "/jwks",
+        "/userinfo",
+    ],
+)
+def test_cors_headers(client: flask.testing.FlaskClient, path: str):
+    response = client.get(path)
+    assert response.headers.get("Access-Control-Allow-Origin") == "*"
+    assert response.headers.get("Access-Control-Allow-Headers") == "*, Authorization"
+    assert (
+        response.headers.get("Access-Control-Allow-Methods")
+        == "GET, POST, PUT, OPTIONS"
+    )
+
+
+def test_authorize_has_no_cors_headers(client: flask.testing.FlaskClient):
+    response = client.get(
+        "/oauth2/authorize",
+        query_string={
+            "client_id": "client",
+            "redirect_uri": "https://example.com/callback",
+            "response_type": "code",
+        },
+    )
+    assert response.headers.get("Access-Control-Allow-Origin") is None
+    assert response.headers.get("Access-Control-Allow-Headers") is None
+    assert response.headers.get("Access-Control-Allow-Methods") is None
 
 
 def test_userinfo_unauthorized(client: flask.testing.FlaskClient):


### PR DESCRIPTION
Hi,
as discussed in #195, here is the PR to close #195.
I have tested it as part of my Single-Page-Application project with success. Until now, I have not received any CORS related error anymore. 

From a security perspective, the usage of the "*" are discussable, but as this is a mock IdP for development purposes only, I think it is acceptable in this case.

### How it looks now:
```HTTP
GET /.well-known/openid-configuration HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, zstd
Connection: keep-alive
Host: localhost:9400
User-Agent: HTTPie/3.2.4


HTTP/1.1 200 OK
Access-Control-Allow-Headers: *, Authorization
Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS
Access-Control-Allow-Origin: *
Content-Length: 792
Content-Type: application/json
date: Fri, 03 Apr 2026 17:22:29 GMT
server: uvicorn

{
    "authorization_endpoint": "http://localhost:9400/oauth2/authorize",
    ...
}
```

---
I hope the modification of the CHANGELOG.md is as intended. The CONTRIBUTING.md defines a the use of a `.CHANGELOG.md`, but there is none, nor couldn't it find any header for `“Unreleased”` changes.