### PR TITLE
return state in error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+- Send `state=` parameter on error responses and not only on authentication success.
+
 ## v0.4.6 - 2026-06-29
 
 - Refreshed access tokens respect the configured `access_token_max_age` ([@masenf][])

--- a/src/oidc_provider_mock/_app.py
+++ b/src/oidc_provider_mock/_app.py
@@ -503,7 +503,8 @@ def authorize() -> flask.typing.ResponseReturnValue:
         if flask.request.form.get("action") == "deny":
             return authorization.handle_response(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
                 *authlib.oauth2.rfc6749.AccessDeniedError(  # pyright: ignore[reportUnknownArgumentType]
-                    redirect_uri=flask.request.args["redirect_uri"]
+                    redirect_uri=flask.request.args["redirect_uri"],
+                    state=flask.request.args.get("state"),
                 )()
             )
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,6 +1,7 @@
 """Tests the authorization code flow via direct HTTP requests."""
 
 import re
+import urllib.parse
 from typing import Any
 
 import httpx
@@ -141,18 +142,27 @@ def test_include_all_claims(oidc_server: str):
     assert user_info["phone"] == claims["phone"]
 
 
-def test_auth_denied(oidc_server: str):
+def test_auth_denied(oidc_server: str, subtests: pytest.Subtests):
     state = faker.password()
 
     client = fake_client(oidc_server)
 
     response = httpx.post(
-        client.authorization_url(state=faker.password()),
+        client.authorization_url(state=state),
         data={"action": "deny"},
     )
 
-    with pytest.raises(AuthorizationError, match=r"access_denied"):
-        client.fetch_token(response.headers["location"], state=state)
+    return_url = response.headers["location"]
+    with subtests.test("regression test: errors should contain the state= parameter"):
+        parsed_url = urllib.parse.urlsplit(return_url)
+        qs = urllib.parse.parse_qs(parsed_url.query)
+        assert qs["state"] == [state]
+
+    with (
+        subtests.test("auth should fail"),
+        pytest.raises(AuthorizationError, match=r"access_denied"),
+    ):
+        client.fetch_token(return_url, state=state)
 
 
 @use_provider_config(require_nonce=True)


### PR DESCRIPTION
The specification[1] requires in 3.1.2.6:
> Unless the Redirection URI is invalid, the Authorization Server returns the Client to the Redirection URI specified in the Authorization Request with the appropriate error and state parameters. Other parameters SHOULD NOT be returned. If the Redirection URI is invalid, the Authorization Server MUST NOT redirect the User Agent to the invalid Redirection URI.

As oidc_provider_mock accepts all redirection URIS, it should always reply with the state parameter if provided.

[1] https://openid.net/specs/openid-connect-core-1_0.html